### PR TITLE
In the :javascript filter in Ruby (HAML) code, the bang equals at the start of the line is not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you use HAML, you will need use a syntax similar to this.
 
 ``` ruby
 :javascript
-  != "App.photos = new Photos(#{@photos.to_json});"
+  App.photos = new Photos(#{@photos.to_json});
 ```
 
 ### In PHP


### PR DESCRIPTION
Since we're primarily showing javascript code with Ruby interpolated, the equals sign is inappropriate. :)
