### PR TITLE
Fix highlight format

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ collection of your server-side models.
 
 If you use HAML, you will need use a syntax similar to this.
 
-``` ruby
+``` haml
 :javascript
   App.photos = new Photos(#{@photos.to_json});
 ```


### PR DESCRIPTION
This code is `haml`, isn't it?
And this code will be highlighted properly.
