### PR TITLE
Fix string syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,17 +256,17 @@ In this example, the function `itemTemplate` is passed onto the parameters for
 
 ``` javascript
 TasksList = Backbone.View.extend({
-  template: _.template("
-    <ul class='task_list'>
-      <% items.each(function(item) { %>
-        <%= itemTemplate(item) %>
-      <% }); %>
-    </ul>
-  "),
+  template: _.template([
+    "<ul class='task_list'>",
+      "<% items.each(function(item) { %>",
+        "<%= itemTemplate(item) %>",
+      "<% }); %>",
+    "</ul>"
+  ].join('')),
 
-  itemTemplate: _.template("
-    <li><%= name %></li>
-  "),
+  itemTemplate: _.template(
+    "<li><%= name %></li>"
+  ),
 
   render: function() {
     var html = this.template({


### PR DESCRIPTION
The string definition containing the new line is syntax error.
I fixed the syntax using `Array.prototype.join`.

Please merge this patch, if you think good this way.

( There are also other ways to join string. For example, using `+`.
But I prefer to use `Array.prototype.join`. )
